### PR TITLE
Remove depends-maven-plugin

### DIFF
--- a/rest/models/pom.xml
+++ b/rest/models/pom.xml
@@ -52,10 +52,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.servicemix.tooling</groupId>
-                <artifactId>depends-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
Fixes warning during install:
```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.connexta.search:index-api-rest-models:jar:0.1.2-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.servicemix.tooling:depends-maven-plugin is missing. @ line 54, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```

This plugin supports generating a file of dependencies, but it isn't being used: https://github.com/apache/servicemix-maven-plugins/tree/master/depends-maven-plugin.