### PR TITLE
Update format of datasetId to UUID

### DIFF
--- a/rest/specs/src/main/filtered-resources/openapi/openapi.yaml
+++ b/rest/specs/src/main/filtered-resources/openapi/openapi.yaml
@@ -119,10 +119,8 @@ components:
       required: true
       schema:
         type: string
-        minLength: 32
-        maxLength: 32
-        pattern: '^[0-9a-zA-Z]+$'
-        example: 00067360b70e4acfab561fe593ad3f7a
+        format: uuid
+        example: 00067360-b70e-4acf-ab56-1fe593ad3f7a
 
   headers:
     ContentVersion:
@@ -156,19 +154,19 @@ components:
             This URL must support HTTP GET to retrieve the file.
           type: string
           format: url
-          example: https://www.example.com/dataset/30f14c6c1fc85cba12bfd093aa8f90e3/file
+          example: https://www.example.com/dataset/30f14c6c-1fc8-5cba-12bf-d093aa8f90e3/file
         metacardLocation:
           description: >
             This URL must support HTTP GET to retrieve the metacard.
           type: string
           format: url
-          example: https://www.example.com/dataset/30f14c6c1fc85cba12bfd093aa8f90e3/metacard
+          example: https://www.example.com/dataset/30f14c6c-1fc8-5cba-12bf-d093aa8f90e3/metacard
         irmLocation:
           description: >
             This URL must support HTTP GET to retrieve the IRM.
           type: string
           format: url
-          example: https://www.example.com/dataset/30f14c6c1fc85cba12bfd093aa8f90e3/irm
+          example: https://www.example.com/dataset/30f14c6c-1fc8-5cba-12bf-d093aa8f90e3/irm
     Version:
       description: Version number.
       type: string


### PR DESCRIPTION
**This PR is ready for review.** It is marked as a draft because https://github.com/connexta/ion-store-api/pull/27 should be merged first.

This PR depends on https://github.com/connexta/ion-store-api/pull/27.

https://github.com/connexta/ion-store-api/pull/27 is the corresponding PR in ion-store-api.

```java
/**
 * NOTE: This class is auto generated by OpenAPI Generator (https://openapi-generator.tech) (4.2.1).
 * https://openapi-generator.tech
 * Do not edit the class manually.
 */
package com.connexta.search.rest.spring;

import com.connexta.search.rest.models.ErrorMessage;
import com.connexta.search.rest.models.IndexRequest;
import java.util.UUID;
import io.swagger.annotations.*;
import org.springframework.http.HttpStatus;
import org.springframework.http.MediaType;
import org.springframework.http.ResponseEntity;
import org.springframework.validation.annotation.Validated;
import org.springframework.web.bind.annotation.PathVariable;
import org.springframework.web.bind.annotation.RequestBody;
import org.springframework.web.bind.annotation.RequestHeader;
import org.springframework.web.bind.annotation.RequestMapping;
import org.springframework.web.bind.annotation.RequestMethod;
import org.springframework.web.bind.annotation.RequestParam;
import org.springframework.web.bind.annotation.RequestPart;
import org.springframework.web.context.request.NativeWebRequest;
import org.springframework.web.multipart.MultipartFile;

import javax.validation.Valid;
import javax.validation.constraints.*;
import java.util.List;
import java.util.Map;
import java.util.Optional;
@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2019-11-25T14:43:30.760549-07:00[America/Phoenix]")

@Validated
@Api(value = "Index", description = "the Index API")
public interface IndexApi {

    default Optional<NativeWebRequest> getRequest() {
        return Optional.empty();
    }

    @ApiOperation(value = "Index Endpoint for datasets.", nickname = "index", notes = "A system can use the Index Endpoint to index a dataset. ", tags={ "index", })
    @ApiResponses(value = { 
        @ApiResponse(code = 200, message = "The index request was successful. "),
        @ApiResponse(code = 400, message = "The client message could not understood by the server due to invalid format or syntax. ", response = ErrorMessage.class),
        @ApiResponse(code = 401, message = "The client could not be authenticated. ", response = ErrorMessage.class),
        @ApiResponse(code = 403, message = "The client does not have permission. ", response = ErrorMessage.class),
        @ApiResponse(code = 501, message = "The requested API version is not supported and therefore not implemented. ", response = ErrorMessage.class) })
    @RequestMapping(value = "/index/{datasetId}",
        produces = { "application/json" }, 
        consumes = { "application/json" },
        method = RequestMethod.PUT)
    default ResponseEntity<Void> index(@ApiParam(value = "The minimal API version from which a client using this API will accept responses. " ,required=true) @RequestHeader(value="Accept-Version", required=true) String acceptVersion,@ApiParam(value = "The ID of the dataset to index using the IRM. ",required=true) @PathVariable("datasetId") UUID datasetId,@ApiParam(value = "The body of the request that includes one IRM that is used to index the dataset. " ,required=true )  @Valid @RequestBody IndexRequest indexRequest) {
        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);

    }

}
```